### PR TITLE
[fix] Remove config.js requirement from utilities.js in production

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var fs = require('fs');
 var twitter = require('twitter');
-var config = require('./config');
+// var config = require('./config');
 /*************************************************************
 Add Underscore Mixin to sort by keys
 **************************************************************/


### PR DESCRIPTION
Heroku is currently crashing because it can't find `config.js` which is required in `utilities.js` but we've put it in our .gitignore.
