### PR TITLE
[feat] Add Node Foreman to track env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 .DS_Store
 config.js
+.env

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save=true
+save-exact=true

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: nodemon app.js

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Trendr
 --------
 
-Testing Heroku's automated deployment at https://mks-trendr.herokuapp.com/#/.
+Heroku: https://mks-trendr.herokuapp.com/#/.
+
+Starting the server: `npm start`
 
 Adding additional views:
 - Make new folder in /public with controller.js file and html view

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
 // process.env.PORT lets the port be set by Heroku
-var port = (process.env.PORT || 3000);
+var port = (process.env.PORT || 5000);
 
 app.get('/api', function(req, res) {
 

--- a/package.json
+++ b/package.json
@@ -1,26 +1,28 @@
 {
   "name": "trendr",
   "version": "1.0.0",
-  "description": "Trendr --------",
+  "description": "Trendr",
   "main": "index.js",
   "scripts": {
+    "start": "nf start",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "./node_modules/bower/bin/bower install"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kcvan/trendr.git"
+    "url": "https://github.com/mks-greenfield/trendr.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Team Trendr",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kcvan/trendr/issues"
+    "url": "https://github.com/mks-greenfield/trendr/issues"
   },
-  "homepage": "https://github.com/kcvan/trendr#readme",
+  "homepage": "https://mks-trendr.herokuapp.com/#/ ",
   "dependencies": {
     "body-parser": "^1.14.2",
     "bower": "^1.7.1",
     "express": "^4.13.3",
+    "foreman": "1.4.1",
     "fs": "0.0.2",
     "morgan": "^1.6.1",
     "path": "^0.12.7",

--- a/utilities.js
+++ b/utilities.js
@@ -1,7 +1,6 @@
 var _ = require('underscore');
 var fs = require('fs');
 var twitter = require('twitter');
-// var config = require('./config');
 /*************************************************************
 Add Underscore Mixin to sort by keys
 **************************************************************/
@@ -20,25 +19,8 @@ _.mixin({
 
 /*************************************************************
 Twitter Config
+All of these process variables live in .env
 **************************************************************/
-
-//Alternatively we can do this: set these locally
-// process.env.CONSUMER_KEY = '';
-// process.env.CONSUMER_SECRET = '';
-// process.env.ACCESS_TOKEN_KEY = '';
-// process.env.ACCESS_TOKEN_SECRET = '';
-
-var consumer_key = process.env.CONSUMER_KEY;
-var consumer_secret = process.env.CONSUMER_SECRET;
-var access_token_key = process.env.ACCESS_TOKEN_KEY;
-var access_token_secret = process.env.ACCESS_TOKEN_SECRET;
-
-//Commenting out local config
-// config.keys.consumer_key;
-// config.keys.consumer_secret
-// config.keys.access_token_key
-// config.keys.access_token_secret
-
 var consumer_key = process.env.CONSUMER_KEY;
 var consumer_secret = process.env.CONSUMER_SECRET;
 var access_token_key = process.env.ACCESS_TOKEN_KEY;


### PR DESCRIPTION
Let's use [Node Foreman](https://github.com/strongloop/node-foreman) to keep track of our environment variables! :balloon: :balloon: :crystal_ball: 

A few notes:
- Install globally to your machine using `npm install -g foreman`
- Create a file called `.env` in your root folder. It's gitignored so it won't be sent with your PR.
- Store any variables in your `.env` that you want 'process.env' to know about. 
- Delete your config.js, you won't be needing it anymore.

For example, since our project currently uses:

```
var consumer_key = process.env.CONSUMER_KEY;
var consumer_secret = process.env.CONSUMER_SECRET;
var access_token_key = process.env.ACCESS_TOKEN_KEY;
var access_token_secret = process.env.ACCESS_TOKEN_SECRET;
```

In your `.env` file you want to have the following:

```
CONSUMER_KEY='asdfjlaksdfj'
CONSUMER_SECRET='aslkdfjalskdjf'
ACCESS_TOKEN_KEY='alskdfjalskdjf'
ACCESS_TOKEN_SECRET='asldkfjalksdjf'
```

Node Foreman needs configuration in both Procfile and package.json to load vars. Since our Procfile specifies `nodemon` make sure you have `nodemon` installed locally. Our `package.json` is set to run `nf start` when you run `node start`, so to start the server/load the vars simply do:

```
$ npm start

> trendr@1.0.0 start /Users/psoshnin/Desktop/makersquare/greenfield/trendr-PERSONAL/trendr
> nf start

[OKAY] Loaded ENV .env File as KEY=VALUE Format
[OKAY] Trimming display Output to 96 Columns
3:22:02 PM web.1 |  [nodemon] 1.8.1
3:22:02 PM web.1 |  [nodemon] to restart at any time, enter `rs`
3:22:02 PM web.1 |  [nodemon] watching: *.*
3:22:02 PM web.1 |  [nodemon] starting `node app.js`
3:22:02 PM web.1 |  Listening on: 5000
```

Make sure to also use `localhost:5000` now :) 
