### PR TITLE
[feat] add us cities ui components

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,9 @@
     "angular": "~1.4.8",
     "angular-route": "~1.4.8",
     "angular-chart.js": "~0.8.8",
-    "spin.js": "spinjs#~2.3.2"
+    "spin.js": "spinjs#~2.3.2",
+    "angular-sanitize": "~1.4.8",
+    "ui-select": "angular-ui-select#~0.13.2",
+    "jquery": "~2.1.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,8 @@
     "spin.js": "spinjs#~2.3.2",
     "angular-sanitize": "~1.4.8",
     "ui-select": "angular-ui-select#~0.13.2",
-    "jquery": "~2.1.4"
+    "jquery": "~2.1.4",
+    "angular-bootstrap": "~0.14.3",
+    "bootstrap": "~3.3.6"
   }
 }

--- a/public/app/components/polina/polinaController.js
+++ b/public/app/components/polina/polinaController.js
@@ -1,9 +1,17 @@
-var app = angular.module('polina', ['ngSanitize','ui.select'])
+angular.module('polina', ['ngSanitize','ui.select'])
 
-app.controller('PolinaController', function($scope, $http) {
+.controller('PolinaController', function($scope, $http) {
 
   $scope.state = {};
   $scope.states = [];
+  $scope.trends = '';
+
+  $scope.$watch('state.selected', function(value) {
+    if ($scope.state.selected) {
+      console.log("watching", $scope.state.selected.name);
+      $scope.getStatesWeeklyTrends($scope.state.selected.name);
+    }
+  });
 
   $scope.getStates = function() {
 
@@ -16,23 +24,36 @@ app.controller('PolinaController', function($scope, $http) {
           $scope.states.push({name: value});
         });
       }, function errorCallback(response) {
+        console.log("error", response);
+      });
+  };
 
+  $scope.getStatesWeeklyTrends = function(stateName) {
+
+    $http({
+      method: 'GET',
+      url: '/api/us/states/'+stateName+'/weeklyvolume'
+    }).then(function successCallback(response) {
+
+        var result = [];
+
+        angular.forEach(response.data, function(value, key) {
+          if (value === 0) {
+          } else {
+            var obj = {};
+            obj.name = key;
+            obj.tweet_volume = value;
+            
+            result.push(obj);
+          }
+        });
+
+        $scope.trends = result;
+
+      }, function errorCallback(response) {
+        console.log("error", response);
       });
   };
 
   $scope.getStates();
-
-
-  // $scope.getUSTopTrends = function() {
-
-  //   $http({
-  //     method: 'GET',
-  //     url: 'api/us/country/today'
-  //   }).then(function successCallback(response) {
-  //       $scope.data = response.data;
-  //     }, function errorCallback(response) {
-
-  //     });
-  // };
-
 });

--- a/public/app/components/polina/polinaController.js
+++ b/public/app/components/polina/polinaController.js
@@ -1,5 +1,38 @@
-angular.module('polina', [])
+var app = angular.module('polina', ['ngSanitize','ui.select'])
 
-.controller('PolinaController', function($scope) {
-  $scope.message = "Polina's div";
+app.controller('PolinaController', function($scope, $http) {
+
+  $scope.state = {};
+  $scope.states = [];
+
+  $scope.getStates = function() {
+
+    $http({
+      method: 'GET',
+      url: '/api/us/states'
+    }).then(function successCallback(response) {
+        response.data.sort();
+        angular.forEach(response.data, function(value) {
+          $scope.states.push({name: value});
+        });
+      }, function errorCallback(response) {
+
+      });
+  };
+
+  $scope.getStates();
+
+
+  // $scope.getUSTopTrends = function() {
+
+  //   $http({
+  //     method: 'GET',
+  //     url: 'api/us/country/today'
+  //   }).then(function successCallback(response) {
+  //       $scope.data = response.data;
+  //     }, function errorCallback(response) {
+
+  //     });
+  // };
+
 });

--- a/public/app/components/polina/polinaView.html
+++ b/public/app/components/polina/polinaView.html
@@ -1,1 +1,28 @@
-<div> {{ message }}</div>
+
+<div ng-controller="PolinaController">
+
+  <h3>Top Weekly Trends by State</h3>
+
+  <ui-select ng-model="state.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;">
+    <ui-select-match placeholder="Search available states">{{$select.selected.name}}</ui-select-match>
+
+    <ui-select-choices repeat="state in states | filter: {name: $select.search}">
+      <div ng-bind-html="state.name | highlight: $select.search"></div>
+
+      <small>
+        <span ng-bind-html="''| highlight: $select.search"></span>
+      </small>
+
+    </ui-select-choices>
+  </ui-select>
+
+  <p>Selected: {{state.selected}}</p>
+
+</div>
+
+
+
+
+
+
+ 

--- a/public/app/components/polina/polinaView.html
+++ b/public/app/components/polina/polinaView.html
@@ -1,7 +1,8 @@
-
 <div ng-controller="PolinaController">
 
   <h3>Top Weekly Trends by State</h3>
+
+  <p>Selected: {{state.selected.name}}</p>
 
   <ui-select ng-model="state.selected" theme="select2" ng-disabled="disabled" style="min-width: 300px;">
     <ui-select-match placeholder="Search available states">{{$select.selected.name}}</ui-select-match>
@@ -16,9 +17,17 @@
     </ui-select-choices>
   </ui-select>
 
-  <p>Selected: {{state.selected}}</p>
+<table>
+  <th>Trend Name</th>  <th>Tweet Volume</th>
+  <tr ng-repeat="trend in trends">
+    <td> {{trend.name}} </td> <td> {{trend.tweet_volume}} </td>
+  </tr>
+</table>
 
 </div>
+
+
+
 
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -2,11 +2,19 @@
   <html ng-app='trendr'>
 
   <head>
+
     <script src="../bower_components/angular/angular.min.js"></script>
     <script src="../bower_components/angular-route/angular-route.min.js"></script>
     <script src="../bower_components/Chart.js/Chart.js"></script>
     <script src="../bower_components/angular-chart.js/dist/angular-chart.js"></script>
     <script src="../bower_components/spin.js/spin.js"></script>
+
+    <!-- libraries Polina added for her component -->
+    <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
+    <script src="../bower_components/ui-select/dist/select.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-select/0.13.2/select.css">
+    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/select2/3.4.5/select2.css">
+
   </head>
 
   <body>
@@ -18,8 +26,7 @@
     <a href="#/polina">Polina</a>
     <a href="#/simon">Simon</a>
     <!-- add link to your route -->
-    
-    <div ng-view></div>
+
     <script src="app/components/chart/chartController.js"></script>
     <script src="app/components/home/homeController.js"></script>
 
@@ -32,6 +39,8 @@
 
     <script src="app/app.routes.js"></script>
     <script src="app/app.module.js"></script>
+
+    <div ng-view></div>
   </body>
 
   </html>

--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,20 @@
     <script src="../bower_components/angular-chart.js/dist/angular-chart.js"></script>
     <script src="../bower_components/spin.js/spin.js"></script>
 
-    <!-- libraries Polina added for her component -->
+    <!-- libraries Polina added specific to her component -->
     <script src="../bower_components/angular-sanitize/angular-sanitize.min.js"></script>
     <script src="../bower_components/ui-select/dist/select.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-select/0.13.2/select.css">
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/select2/3.4.5/select2.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/3.4.5/select2.css">
+
+    <script src="../bower_components/angular-bootstrap/ui-bootstrap.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="../bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+
+
+    <link rel="stylesheet" src="../bower_components/bootstrap/dist/css/bootstrap.min.css">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 
   </head>
 

--- a/utilities/queries/usTrendQueries.js
+++ b/utilities/queries/usTrendQueries.js
@@ -17,11 +17,11 @@ startofToday.setHours(0);
 startofToday.setMinutes(0);
 startofToday.setSeconds(0);
 
-var sevenDaysAgo = new Date() 
-sevenDaysAgo.setDate(sevenDaysAgo.getDate()-7) 
-sevenDaysAgo.setHours(0)
-sevenDaysAgo.setMinutes(0)
-sevenDaysAgo.setSeconds(0)
+var sevenDaysAgo = new Date(); 
+sevenDaysAgo.setDate(sevenDaysAgo.getDate()-7); 
+sevenDaysAgo.setHours(0);
+sevenDaysAgo.setMinutes(0);
+sevenDaysAgo.setSeconds(0);
 /*************************************************************
 Citywide
 **************************************************************/
@@ -30,7 +30,7 @@ Citywide
 exports.distinctCities = function(cb) {
   USTrend.distinct("location_name")
          .exec(cb);
-}
+};
 
 //Return all distinct trends for a city in the last 7 days
 exports.weeklyTrendsByCity = function(cityName, cb) {
@@ -38,7 +38,7 @@ exports.weeklyTrendsByCity = function(cityName, cb) {
          .where({location_name: cityName, 
                  created_at: {$gt: sevenDaysAgo, $lt: today}})
          .exec(cb);
-}
+};
 
 //Returns tweet volume for a trend in a city over the last 7 days
 exports.weeklyTweetVolumeByCityTrend = function(trendName, cityName, cb) {
@@ -47,7 +47,7 @@ exports.weeklyTweetVolumeByCityTrend = function(trendName, cityName, cb) {
          .select('trend_name tweet_volume created_at')
          //.limit(2) //there seems to be only 1 thing so far for each trend, wierd
          .exec(cb);
-}
+};
 
 //Returns the distinct trends and tweet volume for that city for 
 //the last 7 days ordered by tweet volume.
@@ -81,7 +81,7 @@ exports.weeklyTweetVolumeRankByCity = function(cityName, cb) {
             city_trend_count[trend] = count;
             next();
           }
-        })
+        });
 
       }, function(err) {
         if (err) {
@@ -95,7 +95,7 @@ exports.weeklyTweetVolumeRankByCity = function(cityName, cb) {
       });
     }
   });
-}
+};
 
 /*************************************************************
 Statewide
@@ -105,7 +105,7 @@ Statewide
 exports.distinctStates = function(cb) {
   USTrend.distinct("state")
          .exec(cb);
-}
+};
 
 //Return all distinct trends for a state in the last 7 days
 exports.weeklyTrendsByState = function(stateName, cb) {
@@ -113,7 +113,7 @@ exports.weeklyTrendsByState = function(stateName, cb) {
          .where({state: stateName, 
                  created_at: {$gt: sevenDaysAgo, $lt: today}})
          .exec(cb);
-}
+};
 
 //Returns tweet volume for a trend in a state over the last 7 days
 exports.weeklyTweetVolumeByStateTrend = function(trendName, stateName, cb) {
@@ -122,7 +122,7 @@ exports.weeklyTweetVolumeByStateTrend = function(trendName, stateName, cb) {
          .select('location_name trend_name tweet_volume created_at')
          //.limit(2) //there seems to be only 1 thing so far for each trend, wierd
          .exec(cb);
-}
+};
 
 //Returns the distinct trends and tweet volume for that state for 
 //the last 7 days ordered by aggregate tweet volume across its
@@ -159,7 +159,7 @@ exports.weeklyTweetVolumeRankByState = function(stateName, cb) {
             state_trend_count[trend] = count;
             next();
           }
-        })
+        });
 
       }, function(err) {
         if (err) {
@@ -173,7 +173,7 @@ exports.weeklyTweetVolumeRankByState = function(stateName, cb) {
       });
     }
   });
-}
+};
 /*************************************************************
 By Trend
 **************************************************************/
@@ -183,7 +183,7 @@ exports.distinctTrendsToday = function(cb) {
   USTrend.distinct("trend_name")
          .where({created_at: {$gt: startofToday, $lt: today}})
          .exec(cb);
-}
+};
 
 //Returns which states had the trend in the last 7 days.
 exports.statesTrendingThisWeek = function(trendName, cb) {
@@ -191,7 +191,7 @@ exports.statesTrendingThisWeek = function(trendName, cb) {
          .where({trend_name : trendName, 
                  created_at: {$gt: sevenDaysAgo, $lt: today}})
          .exec(cb);
-}
+};
 
 //Returns a count of cities having a trend yesterday.
 exports.cityCountTrendingToday = function(trendName, cb) {
@@ -200,7 +200,7 @@ exports.cityCountTrendingToday = function(trendName, cb) {
          .where({trend_name : trendName,
                  created_at: {$gt: startofToday, $lt: today}})
          .exec(cb);
-}
+};
 
 //Returns a list of cities having a trend this past week.
 exports.citiesTrendingThisWeek = function(trendName, cb) {
@@ -208,7 +208,7 @@ exports.citiesTrendingThisWeek = function(trendName, cb) {
          .where({trend_name : trendName, 
                  created_at: {$gt: sevenDaysAgo, $lt: today}})
          .exec(cb);
-}
+};
 
 /*************************************************************
 Countrywide
@@ -252,4 +252,4 @@ exports.usTrendsToday = function(cb) {
       });
     }
   });
-}
+};

--- a/utilities/shared/shared.js
+++ b/utilities/shared/shared.js
@@ -45,5 +45,5 @@ exports.sortKeysBy = function(obj) {
     return _.sortKeysBy(obj, function (value, key) {
             //changes from ascending to descending sort
             return -(value);
-          })
-}
+          });
+};


### PR DESCRIPTION
## Summary of Changes
- Add drop down menu that is pre-populated with available US cities that have trending data using `api/us/cities`
- Add search/filter feature to drop down.
- Add ability to see top trends for a state after selecting state from drop down using `/api/us/states/:statename/weeklyvolume`
- Ran `grunt jshint` to clean up missing semi colons.

Added following new Angular libraries:
- angular-sanitize
- ui-select
- bootstrap (haven't used this yet)
- angular bootstrap (haven't used this yet)

Rough gif for your viewing pleasure (will work on my gif making skills);
http://g.recordit.co/ykcG5gAVke.gif
